### PR TITLE
Build the index page in a cross platform manner

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,13 @@
   "scripts": {
     "test": "rm -rf ./cdn.db && rm -rf ./test/cdn.db && tap ./test/*.js",
     "start": "node ./bin/browserify-cdn",
-    "index-page": "marked README.md | sed s_https://wzrd.in/standalone/concat-stream@latest_/standalone/concat-stream@latest_ | sed 's_<p>Also, <a href=\"https://wzrd.in\">wzrd.in</a> has a nice url generating form.</p>_<form method=\"get\" id=\"url-generator\"><h3>Or choose a module here:</h3><label>Module:<input type=\"text\" name=\"module\" value=\"concat-stream\" required /></label><label>Version:<input type=\"text\" name=\"ver\" value=\"latest\" required /></label><input type=\"submit\" value=\"Go!\" /></form>_' | exercise-bike --readme :stdin: ./templates/index.handlebars ./public/index.html"
+    "index-page": "marked README.md | node -e \"var Replacer = require('replacer'); process.stdin.pipe(new Replacer('https://wzrd.in/standalone/concat-stream@latest', '/standalone/concat-stream@latest')).pipe(new Replacer('<p>Also, <a href=\\\"https://wzrd.in\\\">wzrd.in</a> has a nice url generating form.</p>', '<form method=\\\"get\\\" id=\\\"url-generator\\\"><h3>Or choose a module here:</h3><label>Module:<input type=\\\"text\\\" name=\\\"module\\\" value=\\\"concat-stream\\\" required /></label><label>Version:<input type=\\\"text\\\" name=\\\"ver\\\" value=\\\"latest\\\" required /></label><input type=\\\"submit\\\" value=\\\"Go!\\\" /></form>')).pipe(process.stdout)\" | exercise-bike --readme :stdin: ./templates/index.handlebars ./public/index.html"
   },
   "devDependencies": {
-    "marked": "~0.3.0",
     "exercise-bike": "0.0.1",
     "jsontool": "~7.0.1",
+    "marked": "~0.3.0",
+    "replacer": "0.0.1",
     "supertest": "~0.9.0",
     "tap": "~0.4.8"
   }


### PR DESCRIPTION
You can do `npm run index-page` on windows, now, if you want.